### PR TITLE
Update lab5-1.ipynb

### DIFF
--- a/modules/lab5/lab5-1.ipynb
+++ b/modules/lab5/lab5-1.ipynb
@@ -634,7 +634,7 @@
    "source": [
     "def cross_corr(\n",
     "    data_frame, # panda dataframe\n",
-    "    method:str='spearman', # type of correlation: either {'pearson', 'kendall', 'spearman'}\n",
+    "    method:str='pearson', # type of correlation: either {'pearson', 'kendall', 'spearman'}\n",
     "    title:str=None, # a string representing the title of your plot\n",
     "    figsize:tuple=(10,10), # a tuple\n",
     "    )->None:\n",
@@ -647,7 +647,7 @@
     "    data_frame: a panda dataframe\n",
     "    \n",
     "    Optional arguments:\n",
-    "    method: default='spearman'; type of correlation: either {'pearson', 'kendall', 'spearman'}\n",
+    "    method: default='pearson'; type of correlation: either {'pearson', 'kendall', 'spearman'}\n",
     "    title: default=None; a string representing the tiltle of your plot\n",
     "    figsize: default=(10,10); # a tuple\n",
     "    \n",


### PR DESCRIPTION
changed the default method for the cross-correlation to [pearson](https://en.wikipedia.org/wiki/Pearson_correlation_coefficient) since that corresponds to the correlation we've been working on in class.